### PR TITLE
Update Qt 5.9 source URL

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.9.6
-$(package)_download_path=https://download.qt.io/official_releases/qt/5.9/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.9/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=eed620cb268b199bd83b3fc6a471c51d51e1dc2dbb5374fc97a0cc75facbe36f


### PR DESCRIPTION
The Windows binaries fail to build because of an invalid Qt 5.9 URL. As it turns out, https://download.qt.io/official_releases/qt/ doesn't provide that version anymore, the minimum official version is 5.12. However, Qt 5.9 can be found at the archive https://download.qt.io/archive/qt/5.9/